### PR TITLE
Register Popup

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,7 @@
     "id-length": "off",
     "import/imports-first": "off",
     "import/newline-after-import": "off",
+    "import/no-named-as-default": "off",
     "import/prefer-default-export": "off",
     "max-len": [
       "warn",

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,14 @@
-import Kinvey, { CacheRack, NetworkRack } from 'kinvey-js-sdk/dist/export';
-import {
-  CacheMiddleware,
-  HttpMiddleware
-} from './middleware';
+import Kinvey, { CacheRack, NetworkRack, User } from 'kinvey-js-sdk/dist/export';
+import { CacheMiddleware, HttpMiddleware } from './middleware';
+import Popup from './popup';
 import Push from './push';
 
 // Setup racks
 CacheRack.useCacheMiddleware(new CacheMiddleware());
 NetworkRack.useHttpMiddleware(new HttpMiddleware());
+
+// Setup popup
+User.usePopupClass(Popup);
 
 // Add the Push module
 Kinvey.Push = Push;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,10 +30,6 @@ module.exports = {
     path: path.join(__dirname, 'dist')
   },
   plugins: [
-    new webpack.BannerPlugin(BANNER, { raw: true }),
-    new webpack.NormalModuleReplacementPlugin(
-      /kinvey-js-sdk\/dist\/identity\/src\/popup\.js/,
-      require.resolve(path.resolve(__dirname, 'dist/popup.js'))
-    )
+    new webpack.BannerPlugin(BANNER, { raw: true })
   ]
 };


### PR DESCRIPTION
#### Description
This PR registers the `Popup` class to use for Mobile Identity Connect using the `usePopupClass()` function on the `User` class.

#### Changes
- Register the `Popup` class in the `index.js` file.
- Remove the logic in the Webpack config to replace the `Popup` class.
