### PR TITLE
Fix Kinvey.initialize

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "es6-promise": "4.1.0",
     "kinvey-js-sdk": "3.8.0",
     "lodash": "4.17.4",
-    "parse-headers": "2.0.1"
+    "parse-headers": "2.0.1",
+    "url": "0.11.0"
   },
   "devDependencies": {
     "babel-cli": "6.24.0",


### PR DESCRIPTION
#### Description
`Kinvey.initialize()` will resolve with an instance of a `Kinvey.User` or `null`. 

#### Changes
- Use the `User` class to resolve with the current active user or `null` for `Kinvey.initialize()`.
- Migrate the active user to the new storage location with `Kinvey.initialize()`.